### PR TITLE
Mac OSX player and Single tick rendering

### DIFF
--- a/4klang_source/4klang.asm
+++ b/4klang_source/4klang.asm
@@ -83,13 +83,11 @@ go4k_synth_commands		dd	0
 						dd	_go4kFST_func@0
 						dd	_go4kPAN_func@0
 						dd	_go4kOUT_func@0
-						dd	_go4kACC_func@0		
+						dd	_go4kACC_func@0
 						dd	_go4kFLD_func@0
 %ifdef	GO4K_USE_GLITCH						
 						dd	_go4kGLITCH_func@0
-%else
-						dd	_go4kFLD_func@0
-%endif						
+%endif 				; Peter Salomonsen removed the else _go4kFLD_func@0 for backwards compatibility with songs not using the GLITCH func
 %ifdef	GO4K_USE_FSTG
 						dd	_go4kFSTG_func@0
 %endif
@@ -1590,7 +1588,11 @@ export_func	_4klang_render@4
 export_func	_4klang_render
 %endif
 	pushad
+%ifdef SINGLE_TICK_RENDERING
+	mov		ecx, dword[__4klang_current_tick] ; get stored current tick
+%else
 	xor		ecx, ecx
+%endif
 %ifdef GO4K_USE_BUFFER_RECORDINGS		
 	push	ecx
 %endif	
@@ -1721,7 +1723,13 @@ go4k_render_nogroove:
 	mov		dword[__4klang_current_tick], ecx
 %endif
 	cmp		ecx, dword MAX_TICKS
+%ifdef SINGLE_TICK_RENDERING
+	jl		no_loop_yet
+	mov		dword[__4klang_current_tick], 0	; loop if at MAX_TICKS
+no_loop_yet:
+%else 
 	jl		go4k_render_tickloop
+%endif
 %ifdef GO4K_USE_BUFFER_RECORDINGS	
 	pop		ecx
 %endif	

--- a/4klang_source/4klang.inc
+++ b/4klang_source/4klang.inc
@@ -11,6 +11,8 @@
 ; //----------------------------------------------------------------------------------------
 ; //	basic defines for the song/synth
 ; //----------------------------------------------------------------------------------------
+;%define AUTHORING					; Use to export the current tick being rendered
+;%define SINGLE_TICK_RENDERING		; Use to render single tick on _4klang_render invocation ( requires AUTHORING enabled )
 %define	SAMPLE_RATE	44100
 %define	MAX_INSTRUMENTS	9
 %define	MAX_VOICES 1
@@ -967,5 +969,7 @@ _go4k_delay_times
 	dw 1516
 	dw 1580
 	dw 1642
-	times 100 dw 0	
+	dw 22050		; Originally times 100 dw 0, but crashes for me (Peter) - so reverted to this found in an older version
+	dw 16537
+	dw 11025
 %endif

--- a/4klang_source/playosx/.gitignore
+++ b/4klang_source/playosx/.gitignore
@@ -1,0 +1,4 @@
+4klangrender
+4klang.asm
+4klang.inc
+4klang.o

--- a/4klang_source/playosx/4klangrender.c
+++ b/4klang_source/playosx/4klangrender.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+
+extern void _4klang_render(void*) __attribute__ ((stdcall));
+extern int _4klang_current_tick;
+
+#define	SAMPLE_RATE	44100
+#define	MAX_INSTRUMENTS	9
+#define	MAX_VOICES 1
+#define	HLD	1 ;	// can be adjusted to give crinkler	some other possibilities
+#define	BPM	100
+#define	MAX_PATTERNS 62
+#define	PATTERN_SIZE_SHIFT 4
+#define	PATTERN_SIZE (1	<< PATTERN_SIZE_SHIFT)
+#define	MAX_TICKS (MAX_PATTERNS*PATTERN_SIZE)
+#define	SAMPLES_PER_TICK (SAMPLE_RATE*4*60/(BPM*16))
+#define	DEF_LFO_NORMALIZE 0.000038
+#define	MAX_SAMPLES	(SAMPLES_PER_TICK*MAX_TICKS)
+
+float buf[SAMPLES_PER_TICK * 2];
+
+int main() {
+    FILE *fp;
+ 
+    _4klang_current_tick = 0;
+
+    fp = fdopen(fileno(stdout), "wb");
+    for(int n=0;n<MAX_TICKS;n++) {        
+        fprintf(stderr,"\nRender %d %d\n",n,_4klang_current_tick);
+        _4klang_render(buf);        
+        fwrite(buf, sizeof(buf), 1, fp);
+    }
+    fclose(fp);
+}

--- a/4klang_source/playosx/README.md
+++ b/4klang_source/playosx/README.md
@@ -1,0 +1,11 @@
+# 4klang rendering example for Mac OSX
+
+In here you'll find `4klangrender.c` which will call the `4klang.asm` library and render one tick
+at the time (using the `AUTHORING` flag in `4klang.inc`).
+
+The `runosx.sh` shell script contains the commands to compile the asm and link with the c example code, and create
+an executable that will ouput a stream of 32 bit floating point samples. By piping into [SOX](http://sox.sourceforge.net/) we'll get sound output.
+
+You also need [YASM](http://yasm.tortall.net/) and gcc (XCode) installed, and if everything is right you should get sound output by simply typing in your terminal (from this folder):
+
+`sh runosx.sh`

--- a/4klang_source/playosx/runosx.sh
+++ b/4klang_source/playosx/runosx.sh
@@ -1,0 +1,9 @@
+echo "Copying 4klang.asm and 4klang.inc from parent dir"
+echo "Enabling SINGLE_TICK_RENDERING (and AUTHORING) flag for rendering example"
+echo "You need sox installed to get audio output"
+sed -e 's/\;\%define SINGLE_TICK_RENDERING/\%define SINGLE_TICK_RENDERING/' ../4klang.inc | \
+    sed -e 's/\;\%define AUTHORING/\%define AUTHORING/' > 4klang.inc
+cp ../4klang.asm .
+yasm -f macho 4klang.asm
+gcc -Wl,-no_pie -m32 4klang.o 4klangrender.c -o 4klangrender
+./4klangrender | sox -t raw -b 32 -e float -r 44100 -c 2 - -d


### PR DESCRIPTION
- Use AUTHORING mode for rendering one tick per invocation of _4klang_render
- Example for running player on Mac OSX

I'm not sure about the purpose of the AUTHORING flag, but I noticed that it stores the current tick - so I assumed that it would be useful to use that stored value when `_4klang_render` is invoked the next time. Also then it made more sense to just render 1 tick instead of the whole song.

If I've misunderstood the purpose of the AUTHORING flag, I can create a new flag instead for adding the feature of rendering a single tick. Rendering of single ticks is useful for having control of the song position, and also to get instant audio output without having to wait for the whole song to be rendered.